### PR TITLE
this alert should be 'critical'

### DIFF
--- a/config/alerts/garage_after_dark.yaml
+++ b/config/alerts/garage_after_dark.yaml
@@ -8,3 +8,8 @@ garage_after_dark:
   skip_first: False
   notifiers:
   - all_ios
+  data:
+    push:
+      sound:
+        name: "alarm.caf"
+        critical: 1


### PR DESCRIPTION
Hey there Jeff!

I was not receiving this alert when 'do not disturb' was enabled, this update fixes that issue.

I took a lot of ideas from your ha config repo, thanks a lot for making it public. Today I am giving back :)

- critical alerts bypass notification dampening settings like "do not disturb'
- we want this alert to get our attention no matter what the iPhone/iWatch settings are
- heads up: this syntax is iOS specific

documentation https://companion.home-assistant.io/docs/notifications/critical-notifications/